### PR TITLE
use setAttribute instead of setAttributeNS

### DIFF
--- a/hooks/attribute-hook.js
+++ b/hooks/attribute-hook.js
@@ -13,5 +13,5 @@ AttributeHook.prototype.hook = function (node, prop, prev) {
         return;
     }
 
-    node.setAttributeNS(null, prop, this.value)
+    node.setAttribute(prop, this.value)
 }


### PR DESCRIPTION
what is the difference? i'm keen to change because min-document does not have setAttributeNS implemented.
