### PR TITLE
Allow passing children as properties.children

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ This means that `dom-delegator` will recognise the event handler
   on that element and correctly call your handler when an a click
   event happens.
 
+#### `children`
+
+If you call `h` with `h('div', { children: "foo" })` it will use
+  `properties.children` as the nodes children instead of the third
+  argument.
+
 ## Installation
 
 `npm install virtual-hyperscript`

--- a/index.js
+++ b/index.js
@@ -52,6 +52,12 @@ function h(tagName, properties, children) {
         props.namespace = undefined
     }
 
+    // properties.children
+    if ("children" in props) {
+      children = props.children
+      props.children = undefined
+    }
+
     // fix cursor bug
     if (tag === "input" &&
         "value" in props &&

--- a/test/h.js
+++ b/test/h.js
@@ -162,3 +162,20 @@ test("h with two ids", function (assert) {
 
     assert.end()
 })
+
+test("h with properties.children", function(assert) {
+  var node = h("#foo", { children: "bar" })
+
+  assert.equal(node.children[0].text, "bar")
+
+  assert.end();
+});
+
+test("h with two children defs", function(assert) {
+  var node = h("#foo", { children: "bar" }, "foo")
+
+  assert.equal(node.children.length, 1)
+  assert.equal(node.children[0].text, "bar")
+
+  assert.end();
+});


### PR DESCRIPTION
If properties.children exists use it as the node's children instead of the third argument.

Add section in readme to note this behavior.

Add tests to test that properties.children is used and that it is used over the third argument (if both are given).

Relevant IRC discussion:

```
11:30:36 AM <parshap> Raynos: what do you think of children being passed as props.children instead of the third argument in virtual-hyperscript? see https://gist.github.com/parshap/87997ec11e90c33296bf
11:32:07 AM <parshap> For me it's easier to modify the tree written this way than deal with weird indentation between the {} and [] when using the third argument
11:32:21 AM <parshap> But maybe there's a better indentation style that I haven't thought of?
11:40:34 AM <neonstalwart> parshap: you could easily write a very thin wrapper on virtual-hyperscript to do that for you if you find it better to write
11:42:10 AM <Raynos> parshap: https://gist.github.com/Raynos/ea4c2f493c33143bea00
11:42:23 AM <Raynos> Only I changed to 4 spaces I could read both
11:42:37 AM <Raynos> I'm open for this change. Patch welcome
```